### PR TITLE
Conduct 440/spike testrail plugin update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,213 @@
 # RobotFramework Testrail
 
+This repo has been forked from https://travis-ci.org/peterservice-rnd/robotframework-testrail
+Refactoring had to be made to allow this plugin to work with TestRail version **v7.5.1.7004**. Additional features added include begin able to pass variables through via a robot framework--variable file and also a module which allows us to create test runs automatically.
+
+Short Description
+---  
+
+[Robot Framework](http://www.robotframework.org) library, listener and pre-run modifiers for working with TestRail.
+
+Installation
+---  
+Add to your project's requirements file:
+
+
+    git+https://github.com/Smarsh/robotframework-testrail@master
+
+Run
+
+    pip install -r {path_to_requirements_file}
+
+## Configuring Robot Test Cases
+This plugin links tests in your Robot Framework suites to TestRail test cases by tags. Each TestRail Test Case has a unique ID which we tag in a corresponding Robot Framework test cases using the following format in a Robot tag:
+
+    testcaseid={test_case_id_value}
+E.g a test case exists in TestRail with the ID = 83920
+The corresponding automated test representing this test case in Robot Framework should be tagged as follows
+
+    ***Tests***
+    Example Test
+      [Tags]	testcaseid=83920
+
+JIRA defect(s)/bug(s) in our Robot Tests can also be added as tags. Defects will be added in the Defects field in TestRail when TestRail test case results are added follow a Robot test run. One or more defects can be tagged as follows:
+
+    defects={defect id(s)}
+
+E.g test case exists in TestRail
+
+    ***Tests***
+    Example Test
+      [Tags]	testcaseid=83920	defects=EG-123,EG-321
+
+
+Modules
+---
+
+**TestRailCreateRun**
+
+- Used as a robot --prerunmodifier
+- Creates a test run in testrail which includes cases for tests which will be executed for a given robot command
+- Tests can be filtered using the --include/-i tagging option in the robot command
+- Tests can be filtered using the --exclude/-i tagging option in the robot command
+
+**TestRailExecuteTestRun**
+
+- Used as robot --prerunmodifier
+- Runs robot suites/test cases based on cases present in a testrail run
+
+**TestRailListener**
+
+- Used as a robot --listener
+- Updates a TestRail test run with results from a robot test run
+
+
+# Configuration
+
+
+Each module can be configured in the command line or in a python variable file passed to robot.
+
+
+## TestRailCreateRun
+
+
+Once the test run has been created the TestRail test run ID will be written to the `testRail.yml` file
+
+
+***Arguments***:
+- *server*: name of TestRail server (string) *required
+- *protocol*: http/https (string) *required
+- *user*: TestRail username (string) *required
+- *password*: TestRail API Key (string) *required
+- *projectId*: ID of the Testrail project to create the test run in (int) *required
+- *testRunTitlePrefix*: Prefix to add to the title/name of the test run (string) *optional
+
+***Set Variables in the command line***
+
+    robot --prerunmodifier TestRailCreateRun:{server}:{user}:{password}:{protocol}:{projectId}:{testRunTitlePrefix} -i includedTags -e excludedTags path/to/tests/*
+
+***Set Variables in a variable file***
+
+variable file named `testRailConfig.py`:
+
+    TESTRAIL_CLIENT_PROTOCOL = '{protocol}'  
+    TESTRAIL_CLIENT_SERVER = '{server}'  
+    TESTRAIL_CLIENT_USER = '{user}'  
+    TESTRAIL_CLIENT_PASSWORD = '{password}'  
+    TESTRAIL_PROJECT_ID = {projectId}  
+    TESTRAIL_RUN_TITLE_PREFIX = 'robot_'  
+
+Insert testRailConfig into robot command:
+
+    robot --prerunmodifier TestRailCreateRun --variableFile testRailConfig.py -i includedTags -e excludedTags path/to/tests*
+
+***Command Examples***
+
+    robot --prerunmodifier TestRailCreateRun --variableFile testRailConfig.py -i includedTags -e excludedTags path/to/tests*
+
+Will create a test run in the provided TestRail project which contains tests from robot suites in the path/to/tests* directories which have a testrailid tag, have a tag matching the includedTag but don't have the tag excluded tag.
+
+    robot --prerunmodifier TestRailCreateRun --variableFile testRailConfig.py  path/to/tests*
+
+Will create a test run in the provided TestRail project which contains all tests from robot suites in the path/to/tests* directories which have a testrailid tag
+
+## TestRailExecuteTestRun
+
+***Arguments***:
+
+- *server*: name of TestRail server (string) *required
+- *protocol*: http/ https (string) *required
+- *user*: TestRail username (string) *required
+- *password*: TestRail API Key (string) *required
+- *run_id*: testRail run id (int) *optional
+- *results_depth*: analysis depth of run results *optional
+- *status_names*: name of test statuses in TestRail *optional
+
+
+
+***Set Variables in the command line***
+
+    robot --prerunmodifier TestRailExecuteTestRun:{server}:{user}:{password}:{protocol}:{results_depth}:{status1}:{status2} path/to/tests/*
+
+***Set Variables in a variable file***
+
+variable file named `testRailConfig.py`:
+
+    TESTRAIL_CLIENT_PROTOCOL = '{protocol}'  
+    TESTRAIL_CLIENT_SERVER = '{server}'  
+    TESTRAIL_CLIENT_USER = '{user}'  
+    TESTRAIL_CLIENT_PASSWORD = '{password}'  
+    TESTRAIL_RUN_ID = {run_id}  
+    RESULTS_DEPTH = '{results_depth}'
+    CASE_STATUSES_TO_RUN = 'status1, status2'
+
+
+Insert testRailConfig into robot command:
+
+    robot --prerunmodifier TestRailExecuteTestRun --variableFile testRailConfig.py -i includedTags -e excludedTags path/to/tests*
+
+***Command Examples***
+
+    robot --prerunmodifier TestRailExecuteTestRun --variableFile testRailConfig.py path/to/tests*
+
+Assuming we have test the TESTRAIL_RUN_ID variables in the testRailConfig.py file the tests from this run will be executed if the have a status which matches a status in the CASE_STATUSES_TO_RUN variable.
+
+    robot --prerunmodifier TestRailCreateRun --prerunmodifier TestRailExecuteTestRun --variableFile testRailConfig.py path/to/tests*
+
+Assuming we have **not** set a TESTRAIL_RUN_ID variable in the testRailConfig.py file. The TestRailCreateRun prerunmodifier will create a test run from all suites/tests in the path/to/tests* directories which have a testrailid tag. The run_id of this test run will be written to the `testRail.yml` file. The testRailExecuteTestRun will read the testRail.yml and pick up the run_id and then only run tests from this run.
+
+## TestRailListener
+
+***Arguments***
+- *server*: name of TestRail server (string) *required
+- *protocol*: http/ https (string) *required
+- *user*: TestRail username (string) *required
+- *password*: TestRail API Key (string) *required
+- *run_id*: Testrail run Id (int) *optional
+- *juggler_disable*: indicator to disable juggler logic; if exists, then juggler logic will be disabled (str) *optional - defaults to off
+- *update*: indicator to update test case in TestRail; if exist, then test will be updated (str) *optional - defaults to off
+
+***Set Variables in the command line***
+
+    robot --listener TestRailListener:{server}:{user}:{password}:{protocol}:{run_id}:{juggler_disable}:{update} path/to/tests/*
+
+***Set Variables in a variable file***
+
+variable file named `testRailConfig.py`:
+
+    TESTRAIL_CLIENT_PROTOCOL = '{protocol}'  
+    TESTRAIL_CLIENT_SERVER = '{server}'  
+    TESTRAIL_CLIENT_USER = '{user}'  
+    TESTRAIL_CLIENT_PASSWORD = '{password}'  
+    TESTRAIL_RUN_ID = {run_id}
+    JUGGLER_DISABLE = '{juggler_disable}'
+    UPDATE_TEST_CASES = '{update}'
+
+
+Insert testRailConfig into robot command:
+
+       robot --listener TestRailListener --variableFile testRailConfig.py path/to/tests/*
+***Command Examples***
+
+
+    robot --prerunmodifier TestRailCreateRun --prerunmodifier TestRailExecuteTestRun --listener TestRailListener --variableFile testRailConfig.py path/to/tests*
+
+Assuming we have **not** set a TESTRAIL_RUN_ID variable in the testRailConfig.py file. The TestRailCreateRun prerunmodifier will create a test run from all suites/tests in the path/to/tests* directories which have a testrailid tag. The run_id of this test run will be written to the `testRail.yml` file. The testRailExecuteTestRun will read the testRail.yml and pick up the run_id and then only run tests from this run. The TestRailListener module will then update the test cases in TestRail with the results from the tests.
+
+Original Readme Docs
 [![Build Status](https://travis-ci.org/peterservice-rnd/robotframework-testrail.svg?branch=master)](https://travis-ci.org/peterservice-rnd/robotframework-testrail)
 
 Short Description
----
+---  
 
-[Robot Framework](http://www.robotframework.org) library, listener and pre-run modifier for working with TestRail.
-
-Installation
----
-
-```
-pip install robotframework-testrail
-```
-
-Documentation
----
-
-See documentation on [GitHub](https://github.com/peterservice-rnd/robotframework-testrail/tree/master/docs).
+[Robot Framework](http://www.robotframework.org) library, listener and pre-run modifiers for working with TestRail.
 
 Usage
----
+---  
 
 [How to enable TestRail API](http://docs.gurock.com/testrail-api2/introduction)
 
-### TestRail API Client
 
-Library for working with [TestRail](http://www.gurock.com/testrail/).
-
-#### Example
-
-```robot
-*** Settings ***
-Library    TestRailAPIClient    host    user    password    run_id
-
-*** Test Cases ***
-Case
-    ${project}=    Get Project    project_id
-    ${section}=    Add Section    project_id=${project['id']    name=New Section
-    ${case}=       Add Case    ${section['id']}    Title    Steps    Description    Refs    type_id    priority_id
-    Update Case    ${case['id']}    request_fields
-```
 
 ### TestRail Listener
 
@@ -52,58 +219,38 @@ Fixing of testing results and updating test cases.
 
 2. Create Robot test:
 
-    ```robot
-    *** Test Cases ***
-    Autotest name
-        [Documentation]    Autotest documentation
-        [Tags]    testrailid=10    defects=BUG-1, BUG-2    references=REF-3, REF-4
-        Fail    Test fail message
-    ```
-
-3. Run Robot Framework with listener:
-
-    ```
-    pybot --listener TestRailListener.py:testrail_server_name:tester_user_name:tester_user_password:run_id:https:update  robot_suite.robot
-    ```
-
-    Test with case_id=10 will be marked as failed in TestRail with message "Test fail message" and defects "BUG-1, BUG-2".
-    
-    Also title, description and references of this test will be updated in TestRail. Parameter "update" is optional.
-
-### TestRail Pre-run Modifier
-
-Pre-run modifier for starting test cases from a certain test run.
-
-#### Example
-
-1. Create Robot test:
-    ```robot
-    *** Test Cases ***
-        Autotest name 1
-        [Documentation]    Autotest 1 documentation
-        [Tags]    testrailid=10
-        Fail    Test fail message
-        Autotest name 2
-        [Documentation]    Autotest 2 documentation
-        [Tags]    testrailid=11
-        Fail    Test fail message
-    ```
-
+    ```robot  
+*** Test Cases *** Autotest name [Documentation]    Autotest documentation [Tags]    testrailid=10    defects=BUG-1, BUG-2    references=REF-3, REF-4 Fail    Test fail message
+ ```  
+3. Run Robot Framework with listener:  
+  
+    ```  
+ pybot --listener TestRailListener.py:testrail_server_name:tester_user_name:tester_user_password:run_id:https:update  robot_suite.robot ```  
+  Test with case_id=10 will be marked as failed in TestRail with message "Test fail message" and defects "BUG-1, BUG-2".  
+      
+    Also title, description and references of this test will be updated in TestRail. Parameter "update" is optional.  
+  
+### TestRail Pre-run Modifier  
+  
+Pre-run modifier for starting test cases from a certain test run.  
+  
+#### Example  
+  
+1. Create Robot test:  
+    ```robot  
+ *** Test Cases *** Autotest name 1 [Documentation]    Autotest 1 documentation [Tags]    testrailid=10 Fail    Test fail message Autotest name 2 [Documentation]    Autotest 2 documentation [Tags]    testrailid=11 Fail    Test fail message  
+ ```  
 2. Run Robot Framework with pre-run modifier:
 
-    ```
-    pybot --prerunmodifier TestRailPreRunModifier:testrail_server_name:tester_user_name:tester_user_password:run_id:http:results_depth robot_suite.robot
-    ```
-
-    Only test cases that are included in the test run _run_id_ will be executed.
+    ```  
+pybot --prerunmodifier TestRailPreRunModifier:testrail_server_name:tester_user_name:tester_user_password:run_id:http:results_depth robot_suite.robot ```  
+Only test cases that are included in the test run _run_id_ will be executed.
 
 3. To execute tests from TestRail test run only with a certain status, for example "failed" and "blocked":
 
-    ```
-    pybot --prerunmodifier TestRailPreRunModifier:testrail_server_name:tester_user_name:tester_user_password:run_ind:http:results_depth:failed:blocked robot_suite.robot
-    ```
-
+    ```  
+pybot --prerunmodifier TestRailPreRunModifier:testrail_server_name:tester_user_name:tester_user_password:run_ind:http:results_depth:failed:blocked robot_suite.robot ```  
 License
----
+---  
 
 Apache License 2.0

--- a/docs/build_libdoc.py
+++ b/docs/build_libdoc.py
@@ -10,7 +10,7 @@ SRC_DIR = realpath(join(DOCS_DIR, '..', 'src'))
 LIBS = {
     'TestRailAPIClient': 'TestRailAPIClient.py::1::2::3::4',
     'TestRailListener': 'TestRailListener.py::1::2::3::4',
-    'TestRailPreRunModifier': 'TestRailPreRunModifier.py::1::2::3::4::5::6'
+    'TestRailPreRunModifier': 'TestRailExecuteTestRun.py::1::2::3::4::5::6'
 }
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-future==0.16.0 ; python_version <= '2.7'
 requests>=2.20.0
 robotframework>=3.0.3

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ with open(path.join(here, 'requirements.txt')) as f:
 
 setup(
     name='robotframework-testrail',
-    version='2.0.1',
+    version='2.1.0',
     description='Robot Framework library, listener and pre-run modifier for working with TestRail',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/peterservice-rnd/robotframework-testrail',
+    url='https://github.com/Smarsh/robotframework-testrail',
     author='JSC PETER-SERVICE',
     author_email='drse_aist_all@billing.ru',
     license='Apache License 2.0',
@@ -35,7 +35,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Framework :: Robot Framework :: Library',
     ],
-    py_modules = ['TestRailAPIClient', 'TestRailListener', 'TestRailPreRunModifier'],
+    py_modules = ['TestRailAPIClient', 'TestRailCreateRun', 'TestRailExecuteTestRun', 'TestRailListener', 'VariableFileParser'],
     keywords='testing testautomation robotframework testrail',
     package_dir={'': 'src'},
     install_requires=requirements,

--- a/src/TestRailCreateRun.py
+++ b/src/TestRailCreateRun.py
@@ -8,7 +8,6 @@ from robot.run import RobotFramework
 import sys
 from TestRailAPIClient import TestRailAPIClient
 from VariableFileParser import VariableFileParser
-from robot.libraries.BuiltIn import BuiltIn
 from datetime import datetime
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -90,8 +89,6 @@ class TestRailCreateRun(SuiteVisitor):
         test_run_title = self.run_title_prefix + "_" + datetime.now().strftime("%d-%m-%YT%H:%M:%S")
 
         self.run_id = str(self.tr_client.add_test_run(self.project_id, test_run_title)['id'])
-
-        BuiltIn().log_to_console("Creating empty TestRail run titled --> "+test_run_title+" : ID --> "+self.run_id)
 
         # store the run ID in a configuration file
         with open('testRail.yml', 'w') as filetowrite:
@@ -180,8 +177,6 @@ class TestRailCreateRun(SuiteVisitor):
                 # if there are no --included tags then just add all the case IDs
                 else:
                     case_id_list.extend(cases_ids)
-
-                BuiltIn().log_to_console("CASE IDS ->"+str(case_id_list))
                 # loop through --excluded tags in the robot command
                 if len(self.robot_options_excluded_tags) > 0:
                     for excl_tag in self.robot_options_excluded_tags:

--- a/src/TestRailCreateRun.py
+++ b/src/TestRailCreateRun.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+
+from concurrent.futures import TimeoutError
+from requests.exceptions import RequestException
+from robot.api import SuiteVisitor, TestSuite
+from robot.output import LOGGER
+from robot.run import RobotFramework
+import sys
+from TestRailAPIClient import TestRailAPIClient
+from VariableFileParser import VariableFileParser
+from robot.libraries.BuiltIn import BuiltIn
+from datetime import datetime
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+CONNECTION_TIMEOUT = 60  # Value in seconds of timeout connection with testrail for one request
+
+
+class TestRailCreateRun(SuiteVisitor):
+    """ This module can be used in as a --prerunmodifier option when executing the robot command to create a test run
+    in test rail based on tests that run according to tests which are set to be included or excluded by tagging
+    in the robot command.
+
+    Configuration for this module can be specified as positional arguments in the robot command
+    e.g robot --prerunmodifier TestRailCreateRun:myserver.com:user@email.com:password:https:1:robot_ robot_tests_dir/*
+
+    or configuration can be done in a variable file
+    e.g robot --prerunmodifier TestRailCreateRun --variableFile myVars.py
+
+    Where myVars.py looks like:
+    TESTRAIL_CLIENT_PROTOCOL = 'https'
+    TESTRAIL_CLIENT_SERVER = 'myServer.com'
+    TESTRAIL_CLIENT_USER = 'user@email.com'
+    TESTRAIL_CLIENT_PASSWORD = 'password'
+    TESTRAIL_PROJECT_ID = 1
+    TESTRAIL_RUN_TITLE_PREFIX = 'robot_'
+
+    The TestRail run title prefix is optional and defaults to robot_.
+    The Testrail Client password should be a users API key.
+    """
+
+    def __init__(self, server: str = None, user: str = None, password: str = None, protocol: str = None,
+                 projectId: str = None, testRunTitlePrefix: str = 'robot_') -> None:
+        """Pre-run modifier initialization.
+
+        *Args:*\n
+            All module args are optional as they can be set as a var in a --variablefile\n.
+            _server_ - name of TestRail server (set in --variablefile as TESTRAIL_CLIENT_SERVER);\n
+            _user_ - name of TestRail user (set in --variablefile as TESTRAIL_CLIENT_USER);\n
+            _password_ - password of TestRail user (set in --variablefile as TESTRAIL_CLIENT_PASSWORD);\n
+            _protocol_ - connecting protocol to TestRail server (set in --variablefile as TESTRAIL_CLIENT_PROTOCOL): http or https;\n
+            project_id_ - ID of project in testrail to create Test Run in (set in --variablefile as TESTRAIL_PROJECT_ID);\n
+            run_title_prefix_ - (Optional)
+        """
+        # Get the command line options passed to the robot command
+        options, arguments = RobotFramework().parse_arguments(sys.argv[1:])
+
+        # if the command line arguments are provided
+        if server is not None:
+            self._protocol = protocol
+            self._server = server
+            self._user = user
+            self._password = password
+            self.project_id = projectId
+            self.run_title_prefix = testRunTitlePrefix
+        # if the command line arguments are not provided look for them in the variablefile(s)
+        else:
+            variable_file_settings = VariableFileParser(options)
+            self._protocol = variable_file_settings.protocol
+            self._server = variable_file_settings.server
+            self._user = variable_file_settings.user
+            self._password = variable_file_settings.password
+            self.project_id = variable_file_settings.projectId
+            self.run_title_prefix = variable_file_settings.runTitlePrefix
+
+        # raise errors if the necessary variable cannot be found
+        if self._protocol is None: raise NameError('variable not defined as arg or in variablefile --> TESTRAIL_CLIENT_PROTOCOL')
+        if self._server is None: raise NameError('variable not defined as arg or in variablefile --> TESTRAIL_CLIENT_SERVER')
+        if self._user is None: raise NameError('variable not defined as arg or in variablefile --> TESTRAIL_CLIENT_USER')
+        if self._password is None: raise NameError('variable not defined as arg or in variablefile --> TESTRAIL_CLIENT_PASSWORD')
+        if self.project_id is None: raise NameError('variable not defined as arg or in variablefile --> TESTRAIL_PROJECT_ID')
+
+        # get the included and excluded tags from the robot command options
+        self.robot_option_included_tags, self.robot_options_excluded_tags = self.get_robot_option_tags(options)
+
+        # instantiate the test rail api client
+        self.tr_client = TestRailAPIClient(self._server, self._user, self._password, 0, self._protocol)
+        LOGGER.register_syslog()
+
+        test_run_title = self.run_title_prefix + "_" + datetime.now().strftime("%d-%m-%YT%H:%M:%S")
+
+        self.run_id = str(self.tr_client.add_test_run(self.project_id, test_run_title)['id'])
+
+        BuiltIn().log_to_console("Creating empty TestRail run titled --> "+test_run_title+" : ID --> "+self.run_id)
+
+        # store the run ID in a configuration file
+        with open('testRail.yml', 'w') as filetowrite:
+            filetowrite.write('[DEFAULT]')
+            filetowrite.write('\nTESTRAIL_RUN_ID = '+self.run_id)
+
+    def get_robot_option_tags(self, options: dict):
+        included_tags = []
+        excluded_tags = []
+        if 'include' in options: included_tags = options['include']
+        if 'exclude' in options: excluded_tags = options['exclude']
+        return included_tags, excluded_tags
+
+    def get_test_rail_ids(self, testcase):
+        test_rail_ids = []
+        for tag in testcase.tags:
+            if 'testrailid=' in str(tag).lower():
+                test_rail_ids.append(str(tag).lower().split('=')[1])
+        if len(test_rail_ids) > 0:
+            return test_rail_ids
+        return None
+
+    def does_testcase_contain_tag(self, testcase, tag):
+        for testcase_tag in testcase.tags:
+            if str(tag).lower() in str(testcase_tag).lower():
+                return True
+        return False
+
+    def _log_to_parent_suite(self, suite: TestSuite, message: str) -> None:
+        """Log message to the parent suite.
+
+        *Args:*\n
+            _suite_ - Robot Framework test suite object.
+            _message_ - message.
+        """
+        if suite.parent is None:
+            LOGGER.error("{suite}: {message}".format(suite=suite, message=message))
+
+    def get_list_of_test_ids_in_testrail_run(self, run_id : str):
+        response = self.tr_client.get_tests_from_test_run(run_id)
+        test_ids = []
+        for test in response['tests']:
+            test_ids.append(test['id'])
+        return test_ids
+
+
+    def end_suite(self, suite: TestSuite) -> None:
+        """This function overrides the default behaviour of the end_suite function allowing us to access test suite
+        information before to execution of tests.
+
+        This function iterates over each test in each suite and identifies which tests contain tags which should be
+        included in test execution.
+
+        - tests must contain a testrailid to be considered for inclusion in TestRail run creation
+        - if a test contains tags matching an --include tag and a testrail id the tag will be added to a list of test
+        cases to add to a TestRail run.
+        - if a test contains tags matching an --exclude tag it will be removed from the list of test cases to add to a
+        TestRail run.
+        - if no --include tags exist then all test cases with a testrail id will be added to the list but removed if
+        test case tags match an --exclude tag.
+
+        Once tags are processed we then add thm to the testrail run.
+
+        *Args:*\n
+             _suite_ - Robot Framework test suite object.
+        """
+        LOGGER.debug("Starting to end suite")
+        case_id_list = []
+        # loop through test cases in tests
+        for testcase in suite.tests:
+            # get case Ids associated with a test
+            cases_ids = self.get_test_rail_ids(testcase)
+
+            # if the there are case Ids in the robot test
+            if cases_ids:
+                # if there are --included tags in the robot command
+                if len(self.robot_option_included_tags) > 0:
+                    # then loop through the --included tags
+                    for tag in self.robot_option_included_tags:
+                        # if there is a match for a testcase tag and --included tag
+                        if self.does_testcase_contain_tag(testcase, tag):
+                            # add the case ids to the list of testcase ids
+                            case_id_list.extend(cases_ids)
+                            # no need to continue looping through the --included tags
+                            break
+                # if there are no --included tags then just add all the case IDs
+                else:
+                    case_id_list.extend(cases_ids)
+
+                BuiltIn().log_to_console("CASE IDS ->"+str(case_id_list))
+                # loop through --excluded tags in the robot command
+                if len(self.robot_options_excluded_tags) > 0:
+                    for excl_tag in self.robot_options_excluded_tags:
+                        # if the test case contains an excluded tag
+                        if self.does_testcase_contain_tag(excl_tag):
+                            # loop through the test case testrail IDs
+                            for case_id in cases_ids:
+                                # if the case Id is in the list then remove
+                                while case_id in case_id_list: case_id_list.remove(case_id)
+                        # no need to do any if the test case doesn't contain excluded tag
+            # if there are no cases IDs then no need to add or exclude any test cases
+
+        try:
+            # if there is any case ID's to add to testrail from this suite
+            if len(case_id_list) > 0:
+                # get existing test ids in testrail run
+                existing_case_ids = self.get_list_of_test_ids_in_testrail_run(self.run_id)
+                # get rid of case ids which already exist in testrail run
+                update_case_ids = list(set(case_id_list + existing_case_ids))
+                for id in update_case_ids:
+                    if id not in existing_case_ids:
+                        # post request sent to add test case to test run
+                        response = self.tr_client.add_test_case_to_run(self.run_id, update_case_ids)
+                        break
+        except (RequestException, TimeoutError) as error:
+            self._log_to_parent_suite(suite, str(error))

--- a/src/TestRailExecuteTestRun.py
+++ b/src/TestRailExecuteTestRun.py
@@ -225,7 +225,7 @@ class TestRailExecuteTestRun(SuiteVisitor):
             self._log_to_parent_suite(suite, str(error))
 
 
-def end_suite(self, suite: TestSuite) -> None:
+    def end_suite(self, suite: TestSuite) -> None:
         """Removing test suites that are empty after excluding tests that are not part of the TestRail test run.
 
         *Args:*\n

--- a/src/TestRailExecuteTestRun.py
+++ b/src/TestRailExecuteTestRun.py
@@ -8,8 +8,6 @@ from robot.api import SuiteVisitor, TestSuite
 from robot.output import LOGGER
 from TestRailAPIClient import TestRailAPIClient, TESTRAIL_STATUS_ID_PASSED
 from robot.run import RobotFramework
-from robot.libraries.BuiltIn import BuiltIn
-import os.path
 import configparser
 import sys
 from os.path import exists

--- a/src/VariableFileParser.py
+++ b/src/VariableFileParser.py
@@ -1,0 +1,53 @@
+import configparser
+
+
+class VariableFileParser(object):
+
+    def __init__(self, cliOptions: dict) -> None:
+        self.sectionName = 'DEFAULT'
+        self.password = None
+        self.user = None
+        self.server = None
+        self.protocol = None
+        self.projectId = None
+        self.runId = None
+        self.runTitlePrefix = None
+        self.testPlanId = None
+
+        if 'variablefile' in cliOptions:
+            variableFiles = cliOptions['variablefile']
+            for varFilePath in variableFiles:
+                parser = configparser.ConfigParser()
+                with open(varFilePath) as stream:
+                    parser.read_string('['+self.sectionName+"]\n" + stream.read())
+                    self.password = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_CLIENT_PASSWORD')
+                    self.user = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_CLIENT_USER')
+                    self.server = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_CLIENT_SERVER')
+                    self.protocol = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_CLIENT_PROTOCOL')
+                    self.projectId = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_PROJECT_ID')
+                    self.runId = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_RUN_ID')
+                    self.runTitlePrefix = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_RUN_TITLE_PREFIX')
+                    self.testPlanId = self.getVariableFromConfig(parser, self.sectionName, 'TESTRAIL_TEST_PLAN_ID')
+                    self.resultsDepth = self.getResultsDepthFromConfig(parser, self.sectionName)
+                    self.statuses = self.getTupleFromConfig(parser, self.sectionName, 'CASE_STATUSES_TO_RUN')
+                    self.suiteId = self.getVariableFromConfig(parser,self.sectionName, 'TESTRAIL_SUITE_ID')
+                    self.updateTestCases = self.getVariableFromConfig(parser, self.sectionName, 'UPDATE_TEST_CASES')
+                    self.jugglerDisable = self.getVariableFromConfig(parser, self.sectionName, 'JUGGLER_DISABLE')
+
+    def getVariableFromConfig(self, parser, sectionName: str, variableName: str):
+        if parser.has_option(sectionName, variableName):
+            return str(parser.get(sectionName, variableName)).replace('"', '').replace("'", "")
+        else:
+            return None
+
+    def getResultsDepthFromConfig(self, parser, sectionName: str):
+        if parser.has_option(sectionName, 'RESULTS_DEPTH'):
+            results_depth = str(self.getVariableFromConfig(parser, sectionName, 'RESULTS_DEPTH'))
+            return int(results_depth) if results_depth.isdigit() else None
+        return 0
+
+    def getTupleFromConfig(self,parser, sectionName: str, variableName: str):
+        if parser.has_option(sectionName, variableName):
+            return tuple(parser.get(sectionName, variableName).replace(" ","").split(","))
+        else:
+            return None


### PR DESCRIPTION
Changed

- Updated readme to include coverage for new features
- added ability to use python variable file to set testrail plugin config
- added module to auto create testrail test run
- renamed module to describe what it does better

To use
Add robotframework-testrail @ git+https://github.com/Smarsh/robotframework-testrail@CONDUCT-440/spike-testrail-plugin-update to requirements.txt
pip install -r requirements.txt

Modify some tags in a robot test suite to include testrailid tags. I have been testing with the following project:
https://smarshcorp.testrail.io/index.php?/projects/overview/44

use ids from test cases in this project to add testrailid tags to your robot tests. e,g
<img width="765" alt="image" src="https://user-images.githubusercontent.com/94852840/165870639-e8238b37-5231-439c-ae0a-185341381ce4.png">

Once you've added these tags you can run a command similar to this: (note you'll need to generate an APIkey for you testrail account and use it here along with your email address)
`robot \                        
--prerunmodifier TestRailCreateRun:smarshcorp.testrail.io:{username}:{apikey}:https:44:test \
--prerunmodifier TestRailExecuteTestRun:smarshcorp.testrail.io:{username}:{apikey}:0:https \
--listener TestRailListener:smarshcorp.testrail.io:{username}:{apikey}:0:https \
-i login \
--dryRun \
tests/integration/*
`

OR add variables to a python variable file 
TESTRAIL_CLIENT_PROTOCOL = 'https'
TESTRAIL_CLIENT_SERVER = 'smarshcorp.testrail.io'
TESTRAIL_CLIENT_USER = '{username}'
TESTRAIL_CLIENT_PASSWORD = '{apikey}'
TESTRAIL_PROJECT_ID = 44
TESTRAIL_RUN_TITLE_PREFIX = 'robot_'

and run the command

`robot \                        
--prerunmodifier TestRailCreateRun \
--prerunmodifier TestRailExecuteTestRun \
--listener TestRailListener \
-i login \
--dryRun \
tests/integration/*
`

if you want to execute an existing testrail test run you can run the following command 
`robot \                        
--prerunmodifier TestRailExecuteTestRun:smarshcorp.testrail.io:{username}:{apikey}:{testRunId}}:https \
--listener TestRailListener:smarshcorp.testrail.io:{username}:{apikey}:0:https \
-i login \
--dryRun \
tests/integration/*
`

or append the following variable with the others mentioned above in your variablefile
TESTRAIL_RUN_ID = 23178(replace with your id)

then run
`robot \                        
--prerunmodifier TestRailExecuteTestRun \
--listener TestRailListener \
-i login \
--dryRun \
tests/integration/*
`


Currently limited to standalone test runs. Test Plans test runs are created and updated with different testrail APIs.
